### PR TITLE
docs: fix Volume parameter range documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ python examples/example_simple.py
 | 参数 | 范围 | 说明 |
 |------|------|------|
 | Speed | 0.5 ~ 2.0 | 语速 |
-| Volume | 0 ~ 10 | 音量 |
+| Volume | 0.01 ~ 10 | 音量（必须大于0） |
 | Pitch | -12 ~ 12 | 音高 |
 
 ### 音频格式

--- a/README_EN.md
+++ b/README_EN.md
@@ -102,7 +102,7 @@ python examples/example_simple.py
 | Parameter | Range | Description |
 |-----------|-------|-------------|
 | Speed | 0.5 ~ 2.0 | Speech speed |
-| Volume | 0 ~ 10 | Volume level |
+| Volume | 0.01 ~ 10 | Volume level (must be > 0) |
 | Pitch | -12 ~ 12 | Pitch adjustment |
 
 ### Audio Format

--- a/examples/example_simple.py
+++ b/examples/example_simple.py
@@ -26,7 +26,7 @@ MODEL = "flow_01_turbo"
 VOICE_CONFIG = {
     "VoiceId": "v-female-R2s4N9qJ",  # Voice ID
     "Speed": 1.0,                    # Speed: [0.5, 2.0], default 1.0
-    "Volume": 1.0,                   # Volume: [0, 10], default 1.0
+    "Volume": 1.0,                   # Volume: (0, 10], must be > 0, default 1.0
     "Pitch": 0,                      # Pitch: [-12, 12], default 0
     "Language": "zh"                 # Language: zh/en/yue/ja/ko, default auto
 }


### PR DESCRIPTION
## Summary

修复 Volume 参数范围的文档错误。根据腾讯云 TRTC API 的实际约束，Volume 参数使用开区间 `(0, 10]`，即 **0 是不允许的**，有效范围是大于 0 且小于等于 10。

## Changes

- `examples/example_simple.py`: 将注释从 `[0, 10]` 修改为 `(0, 10], must be > 0`
- `README.md`: 将范围从 `0 ~ 10` 修改为 `0.01 ~ 10`，并添加说明"必须大于0"
- `README_EN.md`: 将范围从 `0 ~ 10` 修改为 `0.01 ~ 10`，并添加说明"must be > 0"

## Background

腾讯云 SDK 中 `Voice` 和 `FlowTTSVoice` 类的文档明确指定 Volume 范围为 `(0, 10]`（左开右闭区间），但 FlowTTS 项目的文档错误地标记为 `[0, 10]` 或 `0 ~ 10`，这可能导致用户尝试设置 Volume=0 时遇到服务器端验证错误。